### PR TITLE
Add chained conversions

### DIFF
--- a/lib/pinion/asset.rb
+++ b/lib/pinion/asset.rb
@@ -1,19 +1,24 @@
 require "digest/md5"
+require "mime/types"
 
 module Pinion
   class Asset
     attr_reader :uncompiled_path, :compiled_path, :from_type, :to_type, :compiled_contents, :length, :mtime,
                 :content_type, :checksum
 
-    def initialize(uncompiled_path, compiled_path, conversion, mtime)
+    def initialize(uncompiled_path, compiled_path, conversions)
       @uncompiled_path = uncompiled_path
       @compiled_path = compiled_path
-      @from_type = conversion.from_type
-      @to_type = conversion.to_type
-      @compiled_contents = conversion.convert(File.read(uncompiled_path))
+      @from_type = conversions.length > 0 ? conversions.first.from_type : nil
+      @to_type = conversions.length > 0 ? conversions.last.to_type : nil
+      @compiled_contents = File.read(uncompiled_path)
+      conversions.each do |conversion|
+        @compiled_contents = conversion.convert(@compiled_contents)
+      end
       @length = Rack::Utils.bytesize(@compiled_contents)
-      @mtime = mtime
-      @content_type = conversion.content_type
+      @mtime = File.stat(uncompiled_path).mtime
+      found_types = MIME::Types.type_for(compiled_path)
+      @content_type = found_types.length > 0 ? found_types.first.content_type : nil
       @checksum = Digest::MD5.hexdigest(@compiled_contents)
     end
 

--- a/lib/pinion/directory_watcher.rb
+++ b/lib/pinion/directory_watcher.rb
@@ -37,11 +37,8 @@ module Pinion
       result
     end
 
-    def latest_mtime_with_suffix(suffix)
-      pattern = "**/*#{DirectoryWatcher.sanitize_for_glob(suffix)}"
-      glob(pattern).reduce(Time.at(0)) { |latest, path| [latest, File.stat(path).mtime].max }
+    def latest_mtime
+      glob("**/*").reduce(Time.at(0)) { |latest, path| [latest, File.stat(path).mtime].max }
     end
-
-    def self.sanitize_for_glob(pattern) pattern.gsub(/[\*\?\[\]\{\}]/) { |match| "\\#{match}" } end
   end
 end

--- a/pinion.gemspec
+++ b/pinion.gemspec
@@ -19,6 +19,7 @@ EOS
   s.require_paths = ["lib"]
 
   s.add_dependency "rack", "~> 1.0"
+  s.add_dependency "mime-types", "~> 1.19"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "yard"


### PR DESCRIPTION
- The result of a conversion is fed into the next conversion with a matching file extension
- Precompiled assets on the filesystem are now treates as `Asset`s, instead of being special-cased
- The `mime-types` gem is now used to guess the MIME type of the compiled asset from the file extension
- `convert()` now takes a `String`->`String` hash, instead of `Symbol`->`Symbol`
